### PR TITLE
Naming Convention

### DIFF
--- a/src/Controller/Api/GroupController.php
+++ b/src/Controller/Api/GroupController.php
@@ -66,13 +66,12 @@ class GroupController extends AbstractController
      * Delete group.
      *
      * @Route("/{group}", methods="DELETE", name="delete_group")
-     *
-     * @param \App\Entity\Group         $group
-     * @param \App\Service\GroupService $service
      * 
-     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     * @param Group $group
+     * @param GroupService $service
+     * @return JsonResponse
      */
-    public function deleteGroup(Group $group, GroupService $service)
+    public function delete(Group $group, GroupService $service)
     {
         $result = $service->deleteGroup($group);
 

--- a/src/Controller/Api/GroupController.php
+++ b/src/Controller/Api/GroupController.php
@@ -30,7 +30,7 @@ class GroupController extends AbstractController
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
-    public function getGroups(GroupService $service)
+    public function index(GroupService $service)
     {
         return new JsonResponse(['groups' => $service->getGroups()], Response::HTTP_OK);
     }

--- a/src/Controller/Api/GroupController.php
+++ b/src/Controller/Api/GroupController.php
@@ -45,7 +45,7 @@ class GroupController extends AbstractController
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
-    public function addGroup(Request $request, GroupService $service)
+    public function store(Request $request, GroupService $service)
     {
         $result = $service->addGroup($request);
 

--- a/src/Controller/Api/UserController.php
+++ b/src/Controller/Api/UserController.php
@@ -25,15 +25,15 @@ class UserController extends AbstractController
     /**
      * Get all users.
      *
-     * @Route(methods="GET", name="get_users")
+     * @Route(methods="GET", name="users")
      *
-     * @param \App\Service\UserService $service
+     * @param UserService $userService
      *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     * @return JsonResponse
      */
-    public function getUsers(UserService $service)
+    public function index(UserService $userService)
     {
-        return new JsonResponse(['users' => $service->getUsers()], Response::HTTP_OK);
+        return new JsonResponse(['users' => $userService->getUsers()], Response::HTTP_OK);
     }
 
     /**

--- a/src/Controller/Api/UserController.php
+++ b/src/Controller/Api/UserController.php
@@ -68,10 +68,10 @@ class UserController extends AbstractController
      *
      * @Route("/{user}", methods="DELETE", name="delete_user")
      *
-     * @param \App\Entity\User         $user
-     * @param \App\Service\UserService $service
+     * @param User $user
+     * @param UserService $service
      *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     * @return JsonResponse
      */
     public function delete(User $user, UserService $service)
     {

--- a/src/Controller/Api/UserController.php
+++ b/src/Controller/Api/UserController.php
@@ -75,7 +75,7 @@ class UserController extends AbstractController
      */
     public function delete(User $user, UserService $service)
     {
-        $result = $service->deleteUser($user);
+        $result = $service->delete($user);
 
         return new JsonResponse([
             'message' => $result->success(),
@@ -87,11 +87,10 @@ class UserController extends AbstractController
      *
      * @Route("/{user}/groups/{group}", methods="POST", name="attach_group")
      *
-     * @param \App\Entity\User         $user
-     * @param \App\Entity\Group        $group
-     * @param \App\Service\UserService $service
-     *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     * @param User $user
+     * @param Group $group
+     * @param UserService $service
+     * @return JsonResponse
      */
     public function attachGroup(User $user, Group $group, UserService $service)
     {

--- a/src/Controller/Api/UserController.php
+++ b/src/Controller/Api/UserController.php
@@ -41,14 +41,14 @@ class UserController extends AbstractController
      *
      * @Route(methods="POST", name="add_user")
      *
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \App\Service\UserService                  $service
+     * @param Request $request
+     * @param UserService $service
      *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     * @return JsonResponse
      */
-    public function addUser(Request $request, UserService $service)
+    public function store(Request $request, UserService $service)
     {
-        $result = $service->addUser($request);
+        $result = $service->add($request);
 
         if ($result->hasError()) {
             return new JsonResponse(['error' => $result->getError()],
@@ -73,7 +73,7 @@ class UserController extends AbstractController
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
-    public function deleteUser(User $user, UserService $service)
+    public function delete(User $user, UserService $service)
     {
         $result = $service->deleteUser($user);
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -8,6 +8,7 @@
 
 namespace App\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
@@ -41,6 +42,11 @@ class User
      * )
      */
     private $groups;
+
+    public function __construct()
+    {
+        $this->groups = new ArrayCollection();
+    }
 
     /**
      * Get id.
@@ -79,33 +85,36 @@ class User
     /**
      * Add group.
      *
-     * @param \App\Entit\Group $group
+     * @param Group $group
      *
      * @return $this
      */
     public function addGroup(Group $group)
     {
-        $this->groups[] = $group;
+        $this->groups->add($group);
 
         return $this;
     }
 
     /**
      * Remove group.
-     * 
-     * @param \App\Entity\Group $group
+     *
+     * @param Group $group
+     * @return $this
      */
     public function removeGroup(Group $group)
     {
         $this->groups->removeElement($group);
+
+        return $this;
     }
 
     /**
      * Get groups.
      *
-     * @return ArrayCollection|null
+     * @return ArrayCollection
      */
-    public function getGroups()
+    public function getGroups(): ArrayCollection
     {
         return $this->groups;
     }

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -110,7 +110,7 @@ class UserService
      *
      * @return \App\Service\ValidatorService
      */
-    public function deleteUser(User $user)
+    public function delete(User $user)
     {
         $this->em->remove($user);
         $this->em->flush();

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -47,11 +47,10 @@ class UserService
     private $user;
 
     /**
-     * Constructor.
-     *
-     * @param \App\Service\ValidatorService        $validator
-     * @param \Doctrine\ORM\EntityManagerInterface $em
-     * @param \App\Repository\UserRepository       $repo
+     * UserService constructor.
+     * @param ValidatorService $validator
+     * @param EntityManagerInterface $em
+     * @param UserRepository $repo
      */
     public function __construct(ValidatorService $validator, EntityManagerInterface $em, UserRepository $repo)
     {

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -77,7 +77,7 @@ class UserService
      *
      * @return \App\Service\ValidatorService
      */
-    public function addUser(Request $request)
+    public function add(Request $request)
     {
         $user = new User();
         $user->setName($request->request->get('name', ''));


### PR DESCRIPTION
ChangeLog
===

 Updated index method in userControllers
---
- Renamed method name to `index` insteadof `getUsers`
- Updated action docs
- Renamed method arg to `$userService` insteadof `$service`

Updated Store Method in userController
---
- Renamed `addUser` method to `store`
- Updated Method docs

Updated Delete Method in userController
---
- Renamed `deleteUser` method to `delete`
- Updated Method docs

Updated User Entity
---
- Defined `groups` as `ArrayCollection`
- Updated methods docs and added typeHints in return

Overall changes 
---
- Renamed `addGroup` method to `store` in groupsController
- Renamed `getGroups` method to `index` in groupsController
- Renamed `deleteGroup` method to `delete` in groupsController